### PR TITLE
Add hlint tool

### DIFF
--- a/ceremonies/2024/run.sh
+++ b/ceremonies/2024/run.sh
@@ -109,3 +109,9 @@ openssl verify \
     "./int-e7.cert.pem" \
     "./int-e8.cert.pem" \
     "./int-e9.cert.pem"
+
+cd ../../hlint
+GOBIN="${TOOLS}/bin" go install ./
+cd -
+
+"${TOOLS}/bin/hlint" *.cert.pem

--- a/ceremonies/2024/run.sh
+++ b/ceremonies/2024/run.sh
@@ -17,7 +17,7 @@ fi
 function setup_ceremony_tool() {
     # If we've been given a path to an executable to use, just use that.
     if [ -n "${CEREMONY_BIN_2024}" ] && [ -x "${CEREMONY_BIN_2024}" ]; then
-        export CEREMONY_BIN="${CEREMONY_BIN_2021}"
+        export CEREMONY_BIN="${CEREMONY_BIN_2024}"
         return 0
     fi
 
@@ -45,7 +45,20 @@ function setup_ceremony_tool() {
     cp "${TOOLS}/boulder/bin/ceremony" "${CEREMONY_BIN}"
 }
 
+function setup_hlint() {
+    if [ -x "${HLINT_BIN}" ]; then
+      return
+    fi
+
+    pwd
+    cd hlint
+    GOBIN="${TOOLS}/bin" go install ./
+    export HLINT_BIN="${TOOLS}/bin/hlint"
+    cd -
+}
+
 setup_ceremony_tool
+setup_hlint
 
 CEREMONY_DIR="$(dirname ${BASH_SOURCE[0]})"
 cd "${CEREMONY_DIR}"
@@ -110,8 +123,4 @@ openssl verify \
     "./int-e8.cert.pem" \
     "./int-e9.cert.pem"
 
-cd ../../hlint
-GOBIN="${TOOLS}/bin" go install ./
-cd -
-
-"${TOOLS}/bin/hlint" *.cert.pem
+"${HLINT_BIN}" *.cert.pem

--- a/hlint/README.md
+++ b/hlint/README.md
@@ -1,0 +1,16 @@
+# hlint
+
+This checks a pile of certificates for consistent correspondence of Subject to
+subjectKeyIdentifier (SKID), and vice versa. If a single Subject appears with
+different SKIDs, or a single SKID appears with different Subjects, it produces
+an error.
+
+Note that this is an opinionated tool: the is no general prohibition on distinct
+Subjects sharing a public key (and thus a SKID), but it is not our practice or
+intention to do so.
+
+# Usage
+
+```
+hlint *.cert.pem
+```

--- a/hlint/README.md
+++ b/hlint/README.md
@@ -9,7 +9,7 @@ Note that this is an opinionated tool: the is no general prohibition on distinct
 Subjects sharing a public key (and thus a SKID), but it is not our practice or
 intention to do so.
 
-# Usage
+## Usage
 
 ```
 hlint *.cert.pem

--- a/hlint/go.mod
+++ b/hlint/go.mod
@@ -1,0 +1,3 @@
+module github.com/letsencrypt/ceremony-demos/hlint
+
+go 1.23.3

--- a/hlint/main.go
+++ b/hlint/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+type certificate struct {
+	*x509.Certificate
+	filename string
+}
+
+func main() {
+	var certs []*certificate
+	for _, f := range os.Args[1:] {
+		c, err := readCert(f)
+		if err != nil {
+			log.Fatal(err)
+		}
+		certs = append(certs, c)
+	}
+
+	// Key: hex bytes of SKID
+	bySKID := make(map[string]*certificate)
+	// Key: raw Subject
+	bySubject := make(map[string]*certificate)
+
+	var errors bool
+	for _, c := range certs {
+		skid := hex.EncodeToString(c.SubjectKeyId)
+		if otherCert, ok := bySKID[skid]; ok && !bytes.Equal(c.RawSubject, otherCert.RawSubject) {
+			fmt.Fprintf(os.Stderr, "SKID %s has conflicting subjects in %s and %s: %s vs %s\n",
+				skid, c.filename, otherCert.filename, c.Subject, otherCert.Subject)
+			errors = true
+		}
+
+		if otherCert, ok := bySubject[string(c.RawSubject)]; ok && !bytes.Equal(c.SubjectKeyId, otherCert.SubjectKeyId) {
+			fmt.Fprintf(os.Stderr, "subject %s has conflicting SKIDs in %s and %s: %x vs %x\n",
+				c.Subject, c.filename, otherCert.filename, c.SubjectKeyId, otherCert.SubjectKeyId)
+			errors = true
+		}
+
+		bySKID[skid] = c
+		bySubject[string(c.RawSubject)] = c
+	}
+
+	if errors {
+		os.Exit(1)
+	}
+}
+
+func readCert(filename string) (*certificate, error) {
+	bytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s: %v", filename, err)
+	}
+	block, _ := pem.Decode(bytes)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM data in %s", filename)
+	}
+	if block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("%s is not a certificate", filename)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing %s: %v", filename, err)
+	}
+	return &certificate{cert, filename}, nil
+}

--- a/hlint/main.go
+++ b/hlint/main.go
@@ -35,13 +35,13 @@ func main() {
 	for _, c := range certs {
 		skid := hex.EncodeToString(c.SubjectKeyId)
 		if otherCert, ok := bySKID[skid]; ok && !bytes.Equal(c.RawSubject, otherCert.RawSubject) {
-			fmt.Fprintf(os.Stderr, "SKID %s has conflicting subjects in %s and %s: %s vs %s\n",
+			fmt.Fprintf(os.Stderr, "SKID %s has conflicting subjects in %q and %q: %q vs %q\n",
 				skid, c.filename, otherCert.filename, c.Subject, otherCert.Subject)
 			errors = true
 		}
 
 		if otherCert, ok := bySubject[string(c.RawSubject)]; ok && !bytes.Equal(c.SubjectKeyId, otherCert.SubjectKeyId) {
-			fmt.Fprintf(os.Stderr, "subject %s has conflicting SKIDs in %s and %s: %x vs %x\n",
+			fmt.Fprintf(os.Stderr, "subject %s has conflicting SKIDs in %q and %q: %q vs %q\n",
 				c.Subject, c.filename, otherCert.filename, c.SubjectKeyId, otherCert.SubjectKeyId)
 			errors = true
 		}


### PR DESCRIPTION
Hwæt! The key-holders in days of old have often held the wrong end of the stick. Strong chains of scrawled signatures tie anchors to entities, tie roots of trust to Toots about Rust. But bygone bindings blunder when bytewise basics are broken. Hlint, eagle-eyed and enterprising, seeks out SKIDs and Subjects, certifying that same is matched with same.

This checks a pile of certificates for consistent correspondence of Subject to subjectKeyIdentifier (SKID), and vice versa. If a single Subject appears with different SKIDs, or a single SKID appears with different Subjects, it produces an error.

Note that this is an opinionated tool: the is no general prohibition on distinct Subjects sharing a public key (and thus a SKID), but it is not our practice or intention to do so.