### PR TITLE
hlint: add signature verification

### DIFF
--- a/hlint/main.go
+++ b/hlint/main.go
@@ -27,32 +27,92 @@ func main() {
 	}
 
 	// Key: hex bytes of SKID
-	bySKID := make(map[string]*certificate)
+	bySKID := make(map[string][]*certificate)
 	// Key: raw Subject
-	bySubject := make(map[string]*certificate)
+	bySubject := make(map[string][]*certificate)
 
 	var errors bool
 	for _, c := range certs {
 		skid := hex.EncodeToString(c.SubjectKeyId)
-		if otherCert, ok := bySKID[skid]; ok && !bytes.Equal(c.RawSubject, otherCert.RawSubject) {
+		if skid == "" {
+			fmt.Fprintf(os.Stderr, "no SKID in %q\n", c.filename)
+		}
+		if otherCerts, ok := bySKID[skid]; ok && !bytes.Equal(c.RawSubject, otherCerts[0].RawSubject) {
 			fmt.Fprintf(os.Stderr, "SKID %s has conflicting subjects in %q and %q: %q vs %q\n",
-				skid, c.filename, otherCert.filename, c.Subject, otherCert.Subject)
+				skid, c.filename, otherCerts[0].filename, c.Subject, otherCerts[0].Subject)
 			errors = true
 		}
 
-		if otherCert, ok := bySubject[string(c.RawSubject)]; ok && !bytes.Equal(c.SubjectKeyId, otherCert.SubjectKeyId) {
+		if otherCerts, ok := bySubject[string(c.RawSubject)]; ok && !bytes.Equal(c.SubjectKeyId, otherCerts[0].SubjectKeyId) {
 			fmt.Fprintf(os.Stderr, "subject %s has conflicting SKIDs in %q and %q: %q vs %q\n",
-				c.Subject, c.filename, otherCert.filename, c.SubjectKeyId, otherCert.SubjectKeyId)
+				c.Subject, c.filename, otherCerts[0].filename, c.SubjectKeyId, otherCerts[0].SubjectKeyId)
 			errors = true
 		}
 
-		bySKID[skid] = c
-		bySubject[string(c.RawSubject)] = c
+		bySKID[skid] = append(bySKID[skid], c)
+		subject := string(c.RawSubject)
+		bySubject[subject] = append(bySubject[subject], c)
+	}
+
+	// For each certificate, if any other certificate in our pool represents its issuer (has an AKID matching its SKID),
+	// verify the signature from that issuer using that certificate.
+	var verified int
+	for _, c := range certs {
+		akid := hex.EncodeToString(c.AuthorityKeyId)
+
+		// First, find issuers by the Authority Key Identifier (AKID)
+		//
+		// Self-signed certificates, may have an empty AKID, in which case we skip this.
+		//
+		// https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.1
+		//     where a CA distributes its public key in the form of a "self-signed"
+		//     certificate, the authority key identifier MAY be omitted.
+		// https://cabforum.org/working-groups/server/baseline-requirements/requirements/#71212-root-ca-extensions
+		//     7.1.2.1.2 Root CA Extensions
+		//     authorityKeyIdentifier	RECOMMENDED
+		selfSigned := bytes.Equal(c.RawIssuer, c.RawSubject)
+		if akid == "" && !selfSigned {
+			fmt.Fprintf(os.Stderr, "no AuthorityKeyId in %q\n", c.filename)
+		}
+
+		issuers := bySKID[akid]
+		if len(issuers) == 0 && akid != "" {
+			fmt.Fprintf(os.Stderr, "no issuer (by AKID) in provided hierarchy for %q (%s)\n", c.filename, akid)
+			errors = true
+		}
+
+		for _, issuer := range issuers {
+			err := c.CheckSignatureFrom(issuer.Certificate)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "signature mismatch for %q signing %q: %v\n", issuer.filename, c.filename, err)
+				errors = true
+			}
+			verified++
+		}
+
+		// Second, find issuers by the Issuer distinguishedName.
+		issuerDN := string(c.RawIssuer)
+		issuers = bySubject[issuerDN]
+		if len(issuers) == 0 {
+			fmt.Fprintf(os.Stderr, "no issuer (by distinguishedName) found in listed hierarchy for %q (%q)\n", c.filename, c.Issuer)
+			errors = true
+		}
+
+		for _, issuer := range issuers {
+			err := c.CheckSignatureFrom(issuer.Certificate)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "signature mismatch for %q signing %q: %v\n", issuer.filename, c.filename, err)
+				errors = true
+			}
+			verified++
+		}
 	}
 
 	if errors {
 		os.Exit(1)
 	}
+
+	fmt.Printf("Read %d certificates and verified %d signatures\n", len(certs), verified)
 }
 
 func readCert(filename string) (*certificate, error) {


### PR DESCRIPTION
For each certificate, find its issuers (by SKID and by Issuer DN), and verify each signature on it.

This introduces an error if no issuer can be found for a given certificate, which means either the inputs need to be a complete hierarchy or the operator needs to selectively ignore some errors. This was necessary to detect some problems that existed in a previous version of the `outputs/` directory, where there was both an Issuer mismatch (due to missing "(FAKE)") and a SKID/AKID mismatch (due to a change in calculation of SKID).

This also verifies that SKID must be nonempty, and AKID must be nonempty except for self-signed certificates.

Here's what the tool now detects when run against the outputs/ directory checked out to b126ea87b6baa9703f00b9b2793993de52e9280e~ (i.e. pre-#16):

<details>

```
SKID 39f19db10e168971f7f8dc2a55dc09cc835a78bb has conflicting subjects in "/ceremony-demos/outputs/2020/root-x2.cert.pem" and "/ceremony-demos/outputs/2020/root-x2-cross.cert.pem": "CN=(FAKE) ISRG Root X2,O=Internet Security Research Group,C=US" vs "CN=(FAKE) ISRG Root X2,O=(FAKE) Internet Security Research Group,C=US"
SKID 66acf1bc77311678eb3aed855c4d1ef5972ab925 has conflicting subjects in "/ceremony-demos/outputs/2021/root-x1-cross.cert.pem" and "/ceremony-demos/outputs/2015/root-x1.cert.pem": "CN=(FAKE) ISRG Root X1,O=(FAKE) Internet Security Research Group,C=US" vs "CN=(FAKE) ISRG Root X1,O=Internet Security Research Group,C=US"
no issuer (by AKID) in provided hierarchy for "/ceremony-demos/outputs/2024/int-e5-cross.cert.pem" (6665d0215e16d02e45e5fe8348d60325e0891f0d)
signature mismatch for "/ceremony-demos/outputs/2015/root-x1.cert.pem" signing "/ceremony-demos/outputs/2024/int-e5-cross.cert.pem": crypto/rsa: verification error
no issuer (by AKID) in provided hierarchy for "/ceremony-demos/outputs/2024/int-e5.cert.pem" (30e0f51d359b49ee347ce703e4a241f362068046)
signature mismatch for "/ceremony-demos/outputs/2020/root-x2.cert.pem" signing "/ceremony-demos/outputs/2024/int-e5.cert.pem": x509: ECDSA verification failure
no issuer (by AKID) in provided hierarchy for "/ceremony-demos/outputs/2024/int-e6-cross.cert.pem" (6665d0215e16d02e45e5fe8348d60325e0891f0d)
signature mismatch for "/ceremony-demos/outputs/2015/root-x1.cert.pem" signing "/ceremony-demos/outputs/2024/int-e6-cross.cert.pem": crypto/rsa: verification error
no issuer (by AKID) in provided hierarchy for "/ceremony-demos/outputs/2024/int-e6.cert.pem" (30e0f51d359b49ee347ce703e4a241f362068046)
signature mismatch for "/ceremony-demos/outputs/2020/root-x2.cert.pem" signing "/ceremony-demos/outputs/2024/int-e6.cert.pem": x509: ECDSA verification failure
no issuer (by AKID) in provided hierarchy for "/ceremony-demos/outputs/2024/int-e7-cross.cert.pem" (6665d0215e16d02e45e5fe8348d60325e0891f0d)
signature mismatch for "/ceremony-demos/outputs/2015/root-x1.cert.pem" signing "/ceremony-demos/outputs/2024/int-e7-cross.cert.pem": crypto/rsa: verification error
no issuer (by AKID) in provided hierarchy for "/ceremony-demos/outputs/2024/int-e7.cert.pem" (30e0f51d359b49ee347ce703e4a241f362068046)
signature mismatch for "/ceremony-demos/outputs/2020/root-x2.cert.pem" signing "/ceremony-demos/outputs/2024/int-e7.cert.pem": x509: ECDSA verification failure
no issuer (by AKID) in provided hierarchy for "/ceremony-demos/outputs/2024/int-e8-cross.cert.pem" (6665d0215e16d02e45e5fe8348d60325e0891f0d)
signature mismatch for "/ceremony-demos/outputs/2015/root-x1.cert.pem" signing "/ceremony-demos/outputs/2024/int-e8-cross.cert.pem": crypto/rsa: verification error
no issuer (by AKID) in provided hierarchy for "/ceremony-demos/outputs/2024/int-e8.cert.pem" (30e0f51d359b49ee347ce703e4a241f362068046)
signature mismatch for "/ceremony-demos/outputs/2020/root-x2.cert.pem" signing "/ceremony-demos/outputs/2024/int-e8.cert.pem": x509: ECDSA verification failure
no issuer (by AKID) in provided hierarchy for "/ceremony-demos/outputs/2024/int-e9-cross.cert.pem" (6665d0215e16d02e45e5fe8348d60325e0891f0d)
signature mismatch for "/ceremony-demos/outputs/2015/root-x1.cert.pem" signing "/ceremony-demos/outputs/2024/int-e9-cross.cert.pem": crypto/rsa: verification error
no issuer (by AKID) in provided hierarchy for "/ceremony-demos/outputs/2024/int-e9.cert.pem" (30e0f51d359b49ee347ce703e4a241f362068046)
signature mismatch for "/ceremony-demos/outputs/2020/root-x2.cert.pem" signing "/ceremony-demos/outputs/2024/int-e9.cert.pem": x509: ECDSA verification failure
no issuer (by AKID) in provided hierarchy for "/ceremony-demos/outputs/2024/int-r10.cert.pem" (6665d0215e16d02e45e5fe8348d60325e0891f0d)
signature mismatch for "/ceremony-demos/outputs/2015/root-x1.cert.pem" signing "/ceremony-demos/outputs/2024/int-r10.cert.pem": crypto/rsa: verification error
no issuer (by AKID) in provided hierarchy for "/ceremony-demos/outputs/2024/int-r11.cert.pem" (6665d0215e16d02e45e5fe8348d60325e0891f0d)
signature mismatch for "/ceremony-demos/outputs/2015/root-x1.cert.pem" signing "/ceremony-demos/outputs/2024/int-r11.cert.pem": crypto/rsa: verification error
no issuer (by AKID) in provided hierarchy for "/ceremony-demos/outputs/2024/int-r12.cert.pem" (6665d0215e16d02e45e5fe8348d60325e0891f0d)
signature mismatch for "/ceremony-demos/outputs/2015/root-x1.cert.pem" signing "/ceremony-demos/outputs/2024/int-r12.cert.pem": crypto/rsa: verification error
no issuer (by AKID) in provided hierarchy for "/ceremony-demos/outputs/2024/int-r13.cert.pem" (6665d0215e16d02e45e5fe8348d60325e0891f0d)
signature mismatch for "/ceremony-demos/outputs/2015/root-x1.cert.pem" signing "/ceremony-demos/outputs/2024/int-r13.cert.pem": crypto/rsa: verification error
no issuer (by AKID) in provided hierarchy for "/ceremony-demos/outputs/2024/int-r14.cert.pem" (6665d0215e16d02e45e5fe8348d60325e0891f0d)
signature mismatch for "/ceremony-demos/outputs/2015/root-x1.cert.pem" signing "/ceremony-demos/outputs/2024/int-r14.cert.pem": crypto/rsa: verification error
```

</details>